### PR TITLE
Product Backlog Item 795: [Hosted Form] Add 'autocomplete="one-time-code"' on OTP input fields to prevent browser and password manager extension to suggest save as password and enable for autocomplete on mobile devices

### DIFF
--- a/HostedForms/OtpAuthentication.html
+++ b/HostedForms/OtpAuthentication.html
@@ -40,7 +40,7 @@
 
                 <div class="form-group">
                     <label class="sr-only" for="form-password">{{Resources.OtpResources.OtpAuthenticationView_OneTimePassword | Escape }}</label>
-                    <input type="password" name="password" placeholder="{{Resources.OtpResources.OtpAuthenticationView_OneTimePassword | Escape }}..." class="form-username form-control required" id="form-password">
+                    <input type="text" name="password" placeholder="{{Resources.OtpResources.OtpAuthenticationView_OneTimePassword | Escape }}..." class="sms-otp form-username form-control required" id="form-password" autofocus autocomplete="one-time-code" inputmode="numeric">
                 </div>
 
                 <div class="form-group">


### PR DESCRIPTION
[Product Backlog Item 795](https://tfs2019.globeteam.com/Safewhere%20Identify/Identify/_workitems/edit/795): [Hosted Form] Add 'autocomplete="one-time-code"' on OTP input fields to prevent browser and password manager extension to suggest save as password and enable for autocomplete on mobile devices